### PR TITLE
Fix/password validation schema fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Before you start, ensure you have [Node.js](https://nodejs.org/en/download/) ins
 
    ```shell
    git checkout develop
-   npm run install
+   npm install
    ```
 
 3. **Initialize** husky

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,10 +3,11 @@ import { Stack } from '@mui/material';
 import { AppBar } from '@mui/material';
 
 import { NavLink } from '@/components/UI/NavLink/NavLink';
-import { useAuth } from '@/hooks/useAuth';
+
+// import { useAuth } from '@/hooks/useAuth';
 
 const Header = () => {
-  const { isAuthenticated } = useAuth();
+  // const { isAuthenticated } = useAuth();
   const theme = useTheme();
 
   return (
@@ -19,14 +20,17 @@ const Header = () => {
     >
       <Stack direction="row" gap={2} justifyContent="center">
         <NavLink to="/">Home</NavLink>
-        {isAuthenticated ? (
+        {/* {isAuthenticated ? (
           <NavLink to="/signout">Sign out</NavLink>
         ) : (
           <>
             <NavLink to="/signin">Sign in</NavLink>
             <NavLink to="/signup">Sign up</NavLink>
           </>
-        )}
+        )} */}
+        <NavLink to="/signin">Sign in</NavLink>
+        <NavLink to="/signup">Sign up</NavLink>
+        <NavLink to="/signout">Sign out</NavLink>
       </Stack>
     </AppBar>
   );

--- a/src/components/LoginForm/schema.ts
+++ b/src/components/LoginForm/schema.ts
@@ -16,20 +16,21 @@ export const schema = yup.object<LoginFormValues>().shape({
       }
       return true;
     })
+
     .matches(/^\S+@\S+\.\S+$/, 'Email must contain a domain name and an "@" symbol'),
   password: yup
     .string()
-    .test('no-space', 'Password cannot contain spaces', (value) => {
-      if (value) {
-        return !value.includes(' ');
-      }
-      return true;
-    })
+    .test(
+      'No-leading-trailing-spaces',
+      'Password cannot contain leading or trailing spaces',
+      (value) => {
+        if (value) return value.length === value.trim().length;
+      },
+    )
     .required('Please, enter a password')
     .min(8, 'Password must be at least 8 characters long')
     .matches(/(?=.*[a-z])/g, 'Password must contain at least one lowercase letter')
     .matches(/(?=.*[A-Z])/g, 'Password must contain at least one uppercase letter')
     .matches(/(?=.*\d)/g, 'Password must contain at least one digit')
-    .matches(/(?=.*[@#$%^&*?!])/g, 'Password must contain at least one special character')
-    .trim(),
+    .matches(/(?=.*[@#$%^&*?!])/g, 'Password must contain at least one special character'),
 });

--- a/src/components/RegistrationForm/ControlledTextField.tsx
+++ b/src/components/RegistrationForm/ControlledTextField.tsx
@@ -12,6 +12,7 @@ interface ControledTextFieldProps {
   fieldName: string;
   nameToSync?: keyof FormValues;
   callback?: (arg: keyof FormValues, val: string) => void;
+  disabled?: boolean;
 }
 
 export const ControlledTextField = ({
@@ -22,6 +23,7 @@ export const ControlledTextField = ({
   fieldName,
   nameToSync,
   callback,
+  disabled,
 }: ControledTextFieldProps) => {
   return (
     <Controller
@@ -41,6 +43,7 @@ export const ControlledTextField = ({
               callback(nameToSync, e.target.value);
             }
           }}
+          disabled={disabled}
         />
       )}
     />

--- a/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/src/components/RegistrationForm/RegistrationForm.tsx
@@ -340,7 +340,10 @@ export function RegistrationForm() {
                     <TextField
                       {...params}
                       label="Country"
-                      inputProps={{ ...params.inputProps, autoComplete: 'none' }}
+                      inputProps={{
+                        ...params.inputProps,
+                        autoComplete: 'none',
+                      }}
                       error={!!errors.billing_country}
                       helperText={errors.billing_country?.message || ' '}
                     />
@@ -350,6 +353,7 @@ export function RegistrationForm() {
                     await trigger(`billing_zipCode`);
                   }}
                   isOptionEqualToValue={(option, value) => option === value}
+                  disabled={useAsBillingAddress}
                 />
               )}
             />
@@ -359,6 +363,7 @@ export function RegistrationForm() {
               errors={errors}
               label="billing_zipCode"
               fieldName="Zip Code"
+              disabled={useAsBillingAddress}
             />
 
             <ControlledTextField
@@ -367,6 +372,7 @@ export function RegistrationForm() {
               errors={errors}
               label="billing_street"
               fieldName="Street"
+              disabled={useAsBillingAddress}
             />
 
             <ControlledTextField
@@ -375,6 +381,7 @@ export function RegistrationForm() {
               errors={errors}
               label="billing_city"
               fieldName="City"
+              disabled={useAsBillingAddress}
             />
             <Controller
               name="useAsDefaultBillingAddress"

--- a/src/components/RegistrationForm/schema.ts
+++ b/src/components/RegistrationForm/schema.ts
@@ -36,19 +36,19 @@ export const schema = yup.object<FormValues>().shape({
     .matches(/^\S+@\S+\.\S+$/, 'Email must contain a domain name and an "@" symbol'),
   password: yup
     .string()
-    .test('no-space', 'Password cannot contain spaces', (value) => {
-      if (value) {
-        return !value.includes(' ');
-      }
-      return true;
-    })
+    .test(
+      'No-leading-trailing-spaces',
+      'Password cannot contain leading or trailing spaces',
+      (value) => {
+        if (value) return value.length === value.trim().length;
+      },
+    )
     .required('Please, enter a password')
     .min(8, 'Password must be at least 8 characters long')
     .matches(/(?=.*[a-z])/g, 'Password must contain at least one lowercase letter')
     .matches(/(?=.*[A-Z])/g, 'Password must contain at least one uppercase letter')
     .matches(/(?=.*\d)/g, 'Password must contain at least one digit')
-    .matches(/(?=.*[@#$%^&*?!])/g, 'Password must contain at least one special character')
-    .trim(),
+    .matches(/(?=.*[@#$%^&*?!])/g, 'Password must contain at least one special character'),
   firstName: yup
     .string()
     .required('Please, enter your name')

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,8 +1,23 @@
-import { Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+import { Box, Typography } from '@mui/material';
 
 const Main = () => {
   return (
     <>
+      <Box
+        sx={{
+          marginTop: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          justifyContent: 'flex-end',
+          width: '100%',
+        }}
+      >
+        <Link to="/signin">Sign in</Link>
+        <Link to="/signup">Sign up</Link>
+      </Box>
       <Typography variant="h3">Main</Typography>
     </>
   );

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,4 +1,6 @@
-import { Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+import { Box, Typography } from '@mui/material';
 
 import { LoginForm } from '@/components/LoginForm/LoginForm';
 
@@ -7,6 +9,19 @@ const SignIn = () => {
     <>
       <Typography variant="h3">Sign in</Typography>
       <LoginForm />
+      <Box
+        sx={{
+          marginTop: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        <Typography variant="h6">Don&rsquo;t have an account yet?</Typography>
+        <Link to="/signup">Sign up</Link>
+      </Box>
     </>
   );
 };

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,4 +1,6 @@
-import { Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+import { Box, Typography } from '@mui/material';
 
 import { RegistrationForm } from '../components/RegistrationForm/RegistrationForm';
 
@@ -7,6 +9,19 @@ const SignUp = () => {
     <>
       <Typography variant="h3">Sign Up</Typography>
       <RegistrationForm />
+      <Box
+        sx={{
+          marginTop: 1,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        <Typography variant="h6">Already have an account?</Typography>
+        <Link to="/signin">Sign in </Link>
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
# Related issue(s)
[RSS-ECOMM-2_17](https://github.com/IggyPope/antique-boutique/issues/37)
[RSS-ECOMM-2_18](https://github.com/IggyPope/antique-boutique/issues/38)

## PR type

- [x] 🍕 Feature
- [x] 🐜 Bugfix
- [ ] ✍ Documentation update
- [ ] 🎨 Code style changes (formatting, renaming)
- [ ] 👨‍💻 Refactoring (no functional changes)
- [ ] 🧪 Test
- [ ] 📦 Chore
- [ ] ⏪ Revert
- [ ] 🚧 Other (please describe):

## Description and rationale

This PR introduces several fixes:
1) Fix of password validation schema both on Sign In and Sign Up pages
2) Disabled Billing address fields on checked "Use as Billing Address" checkbox
3) Readme file script command fix
4) Temporarily deactivated pages Sign In and Sign Up hiding for signed in users
And one feature:
1) Added cross-links to all pages

## Demo

![image](https://github.com/IggyPope/antique-boutique/assets/119964764/012a6ea1-baaa-4ea3-bbd9-7a9a169da42a)
![image](https://github.com/IggyPope/antique-boutique/assets/119964764/5f8d25bb-f79e-4066-b83b-540259ddcd0c)
![image](https://github.com/IggyPope/antique-boutique/assets/119964764/4427179e-8d17-49a8-a62e-05ef18183b0f)

## Added tests?

- [ ] 👍 Yes
- [ ] 🙅‍♂️ No, because it's not necessary
- [x] 🆘 No, because I need help
