### PR TITLE
fix: labeling addresses while creating user

### DIFF
--- a/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/src/components/RegistrationForm/RegistrationForm.tsx
@@ -108,6 +108,8 @@ export function RegistrationForm() {
       ],
       defaultBillingAddress: data.useAsDefaultBillingAddress ? billingAddressIndex : undefined,
       defaultShippingAddress: data.useAsDefaultShippingAddress ? shippingAddressIndex : undefined,
+      shippingAddresses: [shippingAddressIndex],
+      billingAddresses: [billingAddressIndex],
     };
 
     signUp(customerDraft);


### PR DESCRIPTION
# Related issue(s)

N/A

## PR type

<!-- Select all applicable, but try to limit yourself to one change type per PR. -->

- [ ] 🍕 Feature
- [x] 🐜 Bugfix
- [ ] ✍ Documentation update
- [ ] 🎨 Code style changes (formatting, renaming)
- [ ] 👨‍💻 Refactoring (no functional changes)
- [ ] 🧪 Test
- [ ] 📦 Chore
- [ ] ⏪ Revert
- [ ] 🚧 Other (please describe):

## Description and rationale

This PR introduces a fix to the issue, where Shipping and Billing addresses weren't correctly labeled in the process of the user creation.

## Demo

N/A

## Added tests?

- [ ] 👍 Yes
- [x] 🙅‍♂️ No, because it's not necessary
- [ ] 🆘 No, because I need help
